### PR TITLE
fix: update vscode and windsurf logos

### DIFF
--- a/mcp-atlassian-extended-cursor-redirect.html
+++ b/mcp-atlassian-extended-cursor-redirect.html
@@ -392,7 +392,7 @@
                 <div class="card">
                     <div class="card-header">
                         <div class="card-icon">
-                            <img src="https://cdn.simpleicons.org/visualstudiocode/007ACC" alt="VS Code" />
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg" alt="VS Code" />
                         </div>
                         <h3 class="card-title">VS Code</h3>
                     </div>
@@ -445,8 +445,8 @@
                 <!-- Windsurf -->
                 <div class="card">
                     <div class="card-header">
-                        <div class="card-icon" style="background:#0ea5e9;">
-                            <img src="https://cdn.simpleicons.org/windsurf/ffffff" alt="Windsurf" />
+                        <div class="card-icon">
+                            <img src="https://cdn.simpleicons.org/windsurf/000000" alt="Windsurf" />
                         </div>
                         <h3 class="card-title">Windsurf</h3>
                     </div>

--- a/mcp-gitlab-cursor-redirect.html
+++ b/mcp-gitlab-cursor-redirect.html
@@ -392,7 +392,7 @@
                 <div class="card">
                     <div class="card-header">
                         <div class="card-icon">
-                            <img src="https://cdn.simpleicons.org/visualstudiocode/007ACC" alt="VS Code" />
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg" alt="VS Code" />
                         </div>
                         <h3 class="card-title">VS Code</h3>
                     </div>
@@ -445,8 +445,8 @@
                 <!-- Windsurf -->
                 <div class="card">
                     <div class="card-header">
-                        <div class="card-icon" style="background:#0ea5e9;">
-                            <img src="https://cdn.simpleicons.org/windsurf/ffffff" alt="Windsurf" />
+                        <div class="card-icon">
+                            <img src="https://cdn.simpleicons.org/windsurf/000000" alt="Windsurf" />
                         </div>
                         <h3 class="card-title">Windsurf</h3>
                     </div>


### PR DESCRIPTION
Fixed broken VS Code SimpleIcons slug by using stable Wikimedia SVG. Updated Windsurf logo to black variant and removed colored background for visual consistency.