### PR TITLE
fix: update page titles and metadata

### DIFF
--- a/mcp-atlassian-extended-cursor-redirect.html
+++ b/mcp-atlassian-extended-cursor-redirect.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
     <!-- SEO & Metadata -->
-    <title>Connect Atlassian Extended MCP Server | Installation Guide</title>
+    <title>Atlassian Extended MCP Server | Installation Gateway</title>
     <meta name="description" content="One-click redirect and installation guide to connect the mcp-atlassian-extended MCP server to Cursor, VS Code, Claude Code, Windsurf, and IntelliJ. Supports Jira custom fields, issue links, attachments, agile boards, sprints, backlog, users, Confluence calendars, time-off tracking, and sprint capacity.">
     <meta name="robots" content="index,follow">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="Connect Atlassian Extended MCP Server">
+    <meta property="og:title" content="Atlassian Extended MCP Server | Installation Gateway">
     <meta property="og:description" content="One-click redirect and installation guide to connect the mcp-atlassian-extended MCP server to your favorite AI coding clients.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Connect Atlassian Extended MCP Server">
+    <meta name="twitter:title" content="Atlassian Extended MCP Server | Installation Gateway">
     <meta name="twitter:description" content="Install the mcp-atlassian-extended MCP server in Cursor, VS Code, Claude Code, Windsurf, and IntelliJ.">
     
     <!-- Canonical Link -->

--- a/mcp-gitlab-cursor-redirect.html
+++ b/mcp-gitlab-cursor-redirect.html
@@ -5,19 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     
     <!-- SEO & Metadata -->
-    <title>Connect GitLab MCP Server | Installation Guide</title>
+    <title>GitLab MCP Server | Installation Gateway</title>
     <meta name="description" content="One-click redirect and installation guide to connect the mcp-gitlab MCP server to Cursor, VS Code, Claude Code, Windsurf, and IntelliJ. Supports projects, MRs, pipelines, CI/CD variables, approvals, issues, code reviews, and more.">
     <meta name="robots" content="index,follow">
     
     <!-- Open Graph -->
-    <meta property="og:title" content="Connect GitLab MCP Server">
+    <meta property="og:title" content="GitLab MCP Server | Installation Gateway">
     <meta property="og:description" content="One-click redirect and installation guide to connect the mcp-gitlab MCP server to your favorite AI coding clients.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vish288.github.io/mcp-gitlab-cursor-redirect.html">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Connect GitLab MCP Server">
+    <meta name="twitter:title" content="GitLab MCP Server | Installation Gateway">
     <meta name="twitter:description" content="Install the mcp-gitlab MCP server in Cursor, VS Code, Claude Code, Windsurf, and IntelliJ.">
     
     <!-- Canonical Link -->


### PR DESCRIPTION
Cleaned up HTML title tags and OpenGraph/Twitter titles to use a more professional formatting.