### PR TITLE
fix: update h1 and subtitle to reflect installation gateway

### DIFF
--- a/mcp-atlassian-extended-cursor-redirect.html
+++ b/mcp-atlassian-extended-cursor-redirect.html
@@ -381,8 +381,8 @@
         <div class="container">
             <div class="hero">
                 <p style="color:var(--text-tertiary);font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:12px;font-size:0.85rem;">MCP Client Tools</p>
-                <h1>Connect Atlassian Extended to top MCP clients</h1>
-                <p>However you like to code, the <strong>mcp-atlassian-extended</strong> server adds Atlassian Extended context to your favorite agentic tools.</p>
+                <h1>Atlassian Extended MCP Server</h1>
+                <p>Installation Gateway to connect the <strong>mcp-atlassian-extended</strong> server to your favorite agentic tools.</p>
             </div>
             
             <h2 class="section-title">MCP clients</h2>

--- a/mcp-gitlab-cursor-redirect.html
+++ b/mcp-gitlab-cursor-redirect.html
@@ -381,8 +381,8 @@
         <div class="container">
             <div class="hero">
                 <p style="color:var(--text-tertiary);font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:12px;font-size:0.85rem;">MCP Client Tools</p>
-                <h1>Connect GitLab to top MCP clients</h1>
-                <p>However you like to code, the <strong>mcp-gitlab</strong> server adds GitLab context to your favorite agentic tools.</p>
+                <h1>GitLab MCP Server</h1>
+                <p>Installation Gateway to connect the <strong>mcp-gitlab</strong> server to your favorite agentic tools.</p>
             </div>
             
             <h2 class="section-title">MCP clients</h2>


### PR DESCRIPTION
Changed the H1 from 'Connect {title} to top MCP clients' to '{title} MCP Server' and simplified the subtitle to emphasize the Installation Gateway.