### PR TITLE
feat: add robust SEO keywords and auto-invoke routing

### DIFF
--- a/mcp-atlassian-extended-cursor-redirect.html
+++ b/mcp-atlassian-extended-cursor-redirect.html
@@ -7,18 +7,23 @@
     <!-- SEO & Metadata -->
     <title>Atlassian Extended MCP Server | Installation Gateway</title>
     <meta name="description" content="One-click redirect and installation guide to connect the mcp-atlassian-extended MCP server to Cursor, VS Code, Claude Code, Windsurf, and IntelliJ. Supports Jira custom fields, issue links, attachments, agile boards, sprints, backlog, users, Confluence calendars, time-off tracking, and sprint capacity.">
-    <meta name="robots" content="index,follow">
+    <meta name="keywords" content="MCP, Model Context Protocol, Atlassian Extended, mcp-atlassian-extended, AI, Claude, Cursor, VS Code, Windsurf, IntelliJ, AI coding assistants">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+    <meta name="author" content="vish288">
     
     <!-- Open Graph -->
     <meta property="og:title" content="Atlassian Extended MCP Server | Installation Gateway">
     <meta property="og:description" content="One-click redirect and installation guide to connect the mcp-atlassian-extended MCP server to your favorite AI coding clients.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html">
+    <meta property="og:site_name" content="MCP Catalog">
+    <meta property="og:image" content="https://vish288.github.io/mcp-catalog-og-image.png">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Atlassian Extended MCP Server | Installation Gateway">
     <meta name="twitter:description" content="Install the mcp-atlassian-extended MCP server in Cursor, VS Code, Claude Code, Windsurf, and IntelliJ.">
+    <meta name="twitter:image" content="https://vish288.github.io/mcp-catalog-og-image.png">
     
     <!-- Canonical Link -->
     <link rel="canonical" href="https://vish288.github.io/mcp-atlassian-extended-cursor-redirect.html">
@@ -575,8 +580,23 @@
         </div>
     </div>
 
-    <!-- Background redirect for initial load (optional velvet-rope) -->
+    <!-- Background redirect for initial load based on query params -->
     <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const installTarget = urlParams.get('install');
+            
+            if (installTarget === 'cursor') {
+                // Custom protocol doesn't navigate away, keeping the gateway open behind it
+                setTimeout(() => { window.location.href = "cursor://anysphere.cursor-deeplink/mcp/install?name=mcp-atlassian-extended&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3AtYXRsYXNzaWFuLWV4dGVuZGVkIl0sImVudiI6eyJKSVJBX1VSTCI6Imh0dHBzOi8veW91ci1jb21wYW55LmF0bGFzc2lhbi5uZXQiLCJKSVJBX1VTRVJOQU1FIjoieW91ci5lbWFpbEBjb21wYW55LmNvbSIsIkpJUkFfQVBJX1RPS0VOIjoieW91cl9hcGlfdG9rZW4iLCJDT05GTFVFTkNFX1VSTCI6Imh0dHBzOi8veW91ci1jb21wYW55LmF0bGFzc2lhbi5uZXQvd2lraSIsIkNPTkZMVUVOQ0VfVVNFUk5BTUUiOiJ5b3VyLmVtYWlsQGNvbXBhbnkuY29tIiwiQ09ORkxVRU5DRV9BUElfVE9LRU4iOiJ5b3VyX2FwaV90b2tlbiJ9fQ=="; }, 300);
+            } else if (installTarget === 'vscode') {
+                // Open VS Code web redirect in a new tab to keep the gateway open
+                setTimeout(() => { window.open("https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian-extended&inputs=%5B%7B%22id%22%3A%22jira-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20URL%22%2C%22default%22%3A%22https%3A//your-company.atlassian.net%22%7D%2C%7B%22id%22%3A%22jira-username%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20Username%20/%20Email%22%7D%2C%7B%22id%22%3A%22jira-api-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20API%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22confluence-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20URL%22%2C%22default%22%3A%22https%3A//your-company.atlassian.net/wiki%22%7D%2C%7B%22id%22%3A%22confluence-username%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20Username%20/%20Email%22%7D%2C%7B%22id%22%3A%22confluence-api-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20API%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-atlassian-extended%22%5D%2C%22env%22%3A%7B%22JIRA_URL%22%3A%22%24%7Binput%3Ajira-url%7D%22%2C%22JIRA_USERNAME%22%3A%22%24%7Binput%3Ajira-username%7D%22%2C%22JIRA_API_TOKEN%22%3A%22%24%7Binput%3Ajira-api-token%7D%22%2C%22CONFLUENCE_URL%22%3A%22%24%7Binput%3Aconfluence-url%7D%22%2C%22CONFLUENCE_USERNAME%22%3A%22%24%7Binput%3Aconfluence-username%7D%22%2C%22CONFLUENCE_API_TOKEN%22%3A%22%24%7Binput%3Aconfluence-api-token%7D%22%7D%7D", "_blank"); }, 300);
+            } else if (installTarget === 'vscode-insiders') {
+                setTimeout(() => { window.open("https://insiders.vscode.dev/redirect/mcp/install?name=mcp-atlassian-extended&inputs=%5B%7B%22id%22%3A%22jira-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20URL%22%2C%22default%22%3A%22https%3A//your-company.atlassian.net%22%7D%2C%7B%22id%22%3A%22jira-username%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20Username%20/%20Email%22%7D%2C%7B%22id%22%3A%22jira-api-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Jira%20API%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22confluence-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20URL%22%2C%22default%22%3A%22https%3A//your-company.atlassian.net/wiki%22%7D%2C%7B%22id%22%3A%22confluence-username%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20Username%20/%20Email%22%7D%2C%7B%22id%22%3A%22confluence-api-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Confluence%20API%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-atlassian-extended%22%5D%2C%22env%22%3A%7B%22JIRA_URL%22%3A%22%24%7Binput%3Ajira-url%7D%22%2C%22JIRA_USERNAME%22%3A%22%24%7Binput%3Ajira-username%7D%22%2C%22JIRA_API_TOKEN%22%3A%22%24%7Binput%3Ajira-api-token%7D%22%2C%22CONFLUENCE_URL%22%3A%22%24%7Binput%3Aconfluence-url%7D%22%2C%22CONFLUENCE_USERNAME%22%3A%22%24%7Binput%3Aconfluence-username%7D%22%2C%22CONFLUENCE_API_TOKEN%22%3A%22%24%7Binput%3Aconfluence-api-token%7D%22%7D%7D&quality=insiders", "_blank"); }, 300);
+            }
+        });
+
         const modalOverlay = document.getElementById('modal-overlay');
         const modalTitle = document.getElementById('modal-title');
         const modalDesc = document.getElementById('modal-desc');

--- a/mcp-gitlab-cursor-redirect.html
+++ b/mcp-gitlab-cursor-redirect.html
@@ -7,18 +7,23 @@
     <!-- SEO & Metadata -->
     <title>GitLab MCP Server | Installation Gateway</title>
     <meta name="description" content="One-click redirect and installation guide to connect the mcp-gitlab MCP server to Cursor, VS Code, Claude Code, Windsurf, and IntelliJ. Supports projects, MRs, pipelines, CI/CD variables, approvals, issues, code reviews, and more.">
-    <meta name="robots" content="index,follow">
+    <meta name="keywords" content="MCP, Model Context Protocol, GitLab, mcp-gitlab, AI, Claude, Cursor, VS Code, Windsurf, IntelliJ, AI coding assistants">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+    <meta name="author" content="vish288">
     
     <!-- Open Graph -->
     <meta property="og:title" content="GitLab MCP Server | Installation Gateway">
     <meta property="og:description" content="One-click redirect and installation guide to connect the mcp-gitlab MCP server to your favorite AI coding clients.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://vish288.github.io/mcp-gitlab-cursor-redirect.html">
+    <meta property="og:site_name" content="MCP Catalog">
+    <meta property="og:image" content="https://vish288.github.io/mcp-catalog-og-image.png">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="GitLab MCP Server | Installation Gateway">
     <meta name="twitter:description" content="Install the mcp-gitlab MCP server in Cursor, VS Code, Claude Code, Windsurf, and IntelliJ.">
+    <meta name="twitter:image" content="https://vish288.github.io/mcp-catalog-og-image.png">
     
     <!-- Canonical Link -->
     <link rel="canonical" href="https://vish288.github.io/mcp-gitlab-cursor-redirect.html">
@@ -563,8 +568,23 @@
         </div>
     </div>
 
-    <!-- Background redirect for initial load (optional velvet-rope) -->
+    <!-- Background redirect for initial load based on query params -->
     <script>
+        document.addEventListener("DOMContentLoaded", function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const installTarget = urlParams.get('install');
+            
+            if (installTarget === 'cursor') {
+                // Custom protocol doesn't navigate away, keeping the gateway open behind it
+                setTimeout(() => { window.location.href = "cursor://anysphere.cursor-deeplink/mcp/install?name=mcp-gitlab&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3AtZ2l0bGFiIl0sImVudiI6eyJHSVRMQUJfVVJMIjoiaHR0cHM6Ly9naXRsYWIuZXhhbXBsZS5jb20iLCJHSVRMQUJfVE9LRU4iOiJnbHBhdC14eHh4eHh4eHh4eHh4eHh4eHh4eCJ9fQ=="; }, 300);
+            } else if (installTarget === 'vscode') {
+                // Open VS Code web redirect in a new tab to keep the gateway open
+                setTimeout(() => { window.open("https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&inputs=%5B%7B%22id%22%3A%22gitlab-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitLab%20URL%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.example.com%22%7D%2C%7B%22id%22%3A%22gitlab-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D", "_blank"); }, 300);
+            } else if (installTarget === 'vscode-insiders') {
+                setTimeout(() => { window.open("https://insiders.vscode.dev/redirect/mcp/install?name=mcp-gitlab&inputs=%5B%7B%22id%22%3A%22gitlab-url%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitLab%20URL%22%2C%22default%22%3A%22https%3A%2F%2Fgitlab.example.com%22%7D%2C%7B%22id%22%3A%22gitlab-token%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22GitLab%20Personal%20Access%20Token%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-gitlab%22%5D%2C%22env%22%3A%7B%22GITLAB_URL%22%3A%22%24%7Binput%3Agitlab-url%7D%22%2C%22GITLAB_TOKEN%22%3A%22%24%7Binput%3Agitlab-token%7D%22%7D%7D&quality=insiders", "_blank"); }, 300);
+            }
+        });
+
         const modalOverlay = document.getElementById('modal-overlay');
         const modalTitle = document.getElementById('modal-title');
         const modalDesc = document.getElementById('modal-desc');


### PR DESCRIPTION
Added robust SEO tags, JSON-LD hints, and a query param router (?install=cursor|vscode) that launches the IDE connection in the background while keeping the user on the Gateway page for the installation guides.