### PR TITLE
feat: add Gemini CLI to MCP Installation Gateway

### DIFF
--- a/src/pages/McpInstall.test.tsx
+++ b/src/pages/McpInstall.test.tsx
@@ -28,83 +28,82 @@ describe('McpInstall Page', () => {
     expect(screen.getByText('Coda MCP Server')).toBeInTheDocument()
   })
 
-  it('all accordions are collapsed by default', () => {
+  it('all accordions are expanded by default', () => {
     renderMcpInstall()
 
-    const buttons = screen.getAllByRole('button', { expanded: false })
-    // 3 accordion buttons should exist
+    const buttons = screen.getAllByRole('button', { expanded: true })
+    // 3 accordion buttons should be expanded
     expect(
-      buttons.filter(b => b.getAttribute('aria-expanded') === 'false').length
+      buttons.filter(b => b.getAttribute('aria-expanded') === 'true').length
     ).toBeGreaterThanOrEqual(3)
 
-    // Client cards should not be visible
-    expect(screen.queryByText('VS Code')).not.toBeInTheDocument()
-    expect(screen.queryByText('Cursor')).not.toBeInTheDocument()
+    // Client cards should be visible
+    expect(screen.getAllByText('VS Code').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Cursor').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('expands accordion on click and shows client cards', async () => {
+  it('collapses accordion on click and re-expands', async () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
     const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    expect(gitlabButton).toHaveAttribute('aria-expanded', 'false')
-
-    await user.click(gitlabButton)
-
     expect(gitlabButton).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByText('VS Code')).toBeInTheDocument()
-    expect(screen.getByText('Cursor')).toBeInTheDocument()
-    expect(screen.getByText('Claude Code')).toBeInTheDocument()
-    expect(screen.getByText('Windsurf')).toBeInTheDocument()
-    expect(screen.getByText('IntelliJ')).toBeInTheDocument()
-    expect(screen.getByText('Claude Desktop')).toBeInTheDocument()
+
+    // Collapse
+    await user.click(gitlabButton)
+    expect(gitlabButton).toHaveAttribute('aria-expanded', 'false')
+
+    // Re-expand
+    await user.click(gitlabButton)
+    expect(gitlabButton).toHaveAttribute('aria-expanded', 'true')
+
+    // All 7 client cards visible in the GitLab section
+    const section = gitlabButton.closest('.border.rounded-xl')!
+    expect(within(section as HTMLElement).getByText('VS Code')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('Cursor')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('Claude Code')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('Windsurf')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('IntelliJ')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('Claude Desktop')).toBeInTheDocument()
+    expect(within(section as HTMLElement).getByText('Gemini CLI')).toBeInTheDocument()
   })
 
-  it('collapses accordion on second click', async () => {
+  it('collapses accordion on click', async () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
     const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-    expect(screen.getByText('VS Code')).toBeInTheDocument()
+    expect(gitlabButton).toHaveAttribute('aria-expanded', 'true')
 
     await user.click(gitlabButton)
     expect(gitlabButton).toHaveAttribute('aria-expanded', 'false')
-    expect(screen.queryByText('VS Code')).not.toBeInTheDocument()
   })
 
-  it('auto-expands when ?server= param matches', () => {
+  it('all accordions expanded even with ?server= param', () => {
     renderMcpInstall('/mcp-install?server=mcp-gitlab')
 
-    // GitLab accordion should be expanded
+    // All accordions should be expanded
     const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
     expect(gitlabButton).toHaveAttribute('aria-expanded', 'true')
-    expect(screen.getByText('VS Code')).toBeInTheDocument()
 
-    // Others should stay collapsed
     const atlassianButton = screen.getByText('Atlassian Extended MCP Server').closest('button')!
-    expect(atlassianButton).toHaveAttribute('aria-expanded', 'false')
+    expect(atlassianButton).toHaveAttribute('aria-expanded', 'true')
   })
 
   it('handles unknown server param gracefully', () => {
     renderMcpInstall('/mcp-install?server=unknown-server')
 
-    // Page renders without crash
+    // Page renders without crash, all accordions expanded
     expect(screen.getByText('GitLab MCP Server')).toBeInTheDocument()
-    // All accordions stay collapsed
-    expect(screen.queryByText('VS Code')).not.toBeInTheDocument()
+    expect(screen.getAllByText('VS Code').length).toBeGreaterThanOrEqual(1)
   })
 
   it('opens modal for Claude Code guide', async () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
-    // Expand GitLab section
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    // Click Claude Code guide button
-    const claudeCodeButton = screen.getByText('Claude Code').closest('button')!
+    // All sections expanded by default — click first Claude Code button
+    const claudeCodeButton = screen.getAllByText('Claude Code')[0].closest('button')!
     await user.click(claudeCodeButton)
 
     // Modal should be visible with correct content
@@ -119,10 +118,7 @@ describe('McpInstall Page', () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    const claudeDesktopButton = screen.getByText('Claude Desktop').closest('button')!
+    const claudeDesktopButton = screen.getAllByText('Claude Desktop')[0].closest('button')!
     await user.click(claudeDesktopButton)
 
     const modal = screen.getByRole('dialog')
@@ -134,10 +130,7 @@ describe('McpInstall Page', () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    const claudeCodeButton = screen.getByText('Claude Code').closest('button')!
+    const claudeCodeButton = screen.getAllByText('Claude Code')[0].closest('button')!
     await user.click(claudeCodeButton)
 
     expect(screen.getByRole('dialog')).toBeInTheDocument()
@@ -152,52 +145,39 @@ describe('McpInstall Page', () => {
     const user = userEvent.setup()
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    const claudeCodeButton = screen.getByText('Claude Code').closest('button')!
+    const claudeCodeButton = screen.getAllByText('Claude Code')[0].closest('button')!
     await user.click(claudeCodeButton)
 
     const copyButton = screen.getByRole('button', { name: /copy to clipboard/i })
     expect(copyButton).toBeInTheDocument()
   })
 
-  it('shows GitHub and PyPI links in expanded section', async () => {
-    const user = userEvent.setup()
+  it('shows GitHub and PyPI links in expanded section', () => {
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
+    // All sections expanded — multiple GitHub/PyPI links exist
+    const githubLinks = screen.getAllByRole('link', { name: /github/i })
+    expect(githubLinks[0]).toHaveAttribute('href', expect.stringContaining('github.com'))
+    expect(githubLinks[0]).toHaveAttribute('target', '_blank')
 
-    const githubLink = screen.getByRole('link', { name: /github/i })
-    expect(githubLink).toHaveAttribute('href', expect.stringContaining('github.com'))
-    expect(githubLink).toHaveAttribute('target', '_blank')
-
-    const pypiLink = screen.getByRole('link', { name: /pypi/i })
-    expect(pypiLink).toHaveAttribute('href', expect.stringContaining('pypi.org'))
-    expect(pypiLink).toHaveAttribute('target', '_blank')
+    const pypiLinks = screen.getAllByRole('link', { name: /pypi/i })
+    expect(pypiLinks[0]).toHaveAttribute('href', expect.stringContaining('pypi.org'))
+    expect(pypiLinks[0]).toHaveAttribute('target', '_blank')
   })
 
-  it('VS Code card renders as a link', async () => {
-    const user = userEvent.setup()
+  it('VS Code card renders as a link', () => {
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    const vscodeLink = screen.getByText('VS Code').closest('a')
+    // All sections expanded — multiple VS Code links exist
+    const vscodeLink = screen.getAllByText('VS Code')[0].closest('a')
     expect(vscodeLink).toBeInTheDocument()
     expect(vscodeLink).toHaveAttribute('href', expect.stringContaining('vscode'))
   })
 
-  it('Cursor card renders as a link with deeplink', async () => {
-    const user = userEvent.setup()
+  it('Cursor card renders as a link with deeplink', () => {
     renderMcpInstall()
 
-    const gitlabButton = screen.getByText('GitLab MCP Server').closest('button')!
-    await user.click(gitlabButton)
-
-    const cursorLink = screen.getByText('Cursor').closest('a')
+    const cursorLink = screen.getAllByText('Cursor')[0].closest('a')
     expect(cursorLink).toBeInTheDocument()
     expect(cursorLink).toHaveAttribute('href', expect.stringContaining('cursor://'))
   })
@@ -221,16 +201,29 @@ describe('McpInstall Page', () => {
   it('ignores unknown install target', () => {
     renderMcpInstall('/mcp-install?server=mcp-gitlab&install=unknown')
 
-    // Accordion should expand but no modal
-    expect(screen.getByText('VS Code')).toBeInTheDocument()
+    // All accordions expanded, no modal for unknown target
+    expect(screen.getAllByText('VS Code').length).toBeGreaterThanOrEqual(1)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('shows correct client count in accordion header', () => {
     renderMcpInstall()
 
-    const clientCounts = screen.getAllByText('6 clients')
+    const clientCounts = screen.getAllByText('7 clients')
     expect(clientCounts).toHaveLength(3)
+  })
+
+  it('opens modal for Gemini CLI guide', async () => {
+    const user = userEvent.setup()
+    renderMcpInstall()
+
+    const geminiButton = screen.getAllByText('Gemini CLI')[0].closest('button')!
+    await user.click(geminiButton)
+
+    const modal = screen.getByRole('dialog')
+    expect(modal).toBeInTheDocument()
+    expect(within(modal).getByText(/gitlab for gemini cli/i)).toBeInTheDocument()
+    expect(within(modal).getByText(/gemini mcp add/)).toBeInTheDocument()
   })
 
   it('renders package name badge in accordion header', () => {

--- a/src/pages/McpInstall.tsx
+++ b/src/pages/McpInstall.tsx
@@ -209,6 +209,14 @@ function generateClaudeCommand(serverKey: string): string {
   return `claude mcp add ${s.shortName} -- ${s.installCommand} ${s.packageName}`
 }
 
+function generateGeminiCommand(serverKey: string): string {
+  const s = getServerOrThrow(serverKey)
+  const envFlags = Object.entries(s.envVars)
+    .map(([key, val]) => `-e ${key}=${val.placeholder || val.default || ''}`)
+    .join(' ')
+  return `gemini mcp add ${envFlags} ${s.shortName} ${s.installCommand} ${s.packageName}`
+}
+
 // ── Client Card Data ────────────────────────────────────────────────
 
 interface ClientCard {
@@ -284,6 +292,16 @@ function getClientCards(serverKey: string): ClientCard[] {
       modalCode: generateConfigJson(serverKey),
       modalDesc: 'Add this to Settings > MCP Servers, or claude_desktop_config.json:',
     },
+    {
+      name: 'Gemini CLI',
+      iconUrl: 'https://cdn.simpleicons.org/googlegemini/ffffff',
+      iconBg: '#4285F4',
+      actionType: 'modal',
+      actionText: 'Guide',
+      modalTitle: `${s.displayName} for Gemini CLI`,
+      modalCode: generateGeminiCommand(serverKey),
+      modalDesc: 'Run this command in your terminal:',
+    },
   ]
 }
 
@@ -298,6 +316,8 @@ const INSTALL_CLIENT_MAP: Record<string, string> = {
   'claude-desktop': 'Claude Desktop',
   windsurf: 'Windsurf',
   intellij: 'IntelliJ',
+  gemini: 'Gemini CLI',
+  'gemini-cli': 'Gemini CLI',
 }
 
 // ── Modal Component ─────────────────────────────────────────────────
@@ -415,7 +435,7 @@ function ServerSection({
     description: string
     code: string
   } | null>(initialModal)
-  const [expanded, setExpanded] = useState(autoExpand)
+  const [expanded, setExpanded] = useState(true)
 
   // Auto-redirect for link-based installs (cursor, vscode)
   useEffect(() => {
@@ -491,7 +511,7 @@ function ServerSection({
           </div>
 
           {/* Client grid — compact pills */}
-          <div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-2'>
+          <div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-2'>
             {clients.map(client => (
               <div key={client.name}>
                 {client.actionType === 'link' ? (
@@ -577,8 +597,8 @@ export default function McpInstall() {
           MCP Installation Gateway
         </h1>
         <p className='text-lg text-muted-foreground max-w-2xl'>
-          One-click installation for MCP servers. Connect to VS Code, Cursor, Claude, Windsurf, and
-          IntelliJ.
+          One-click installation for MCP servers. Connect to VS Code, Cursor, Claude, Windsurf,
+          IntelliJ, and Gemini CLI.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary

- Add Gemini CLI as 7th client card in the MCP Installation Gateway
- All server sections now expand by default (no collapse on page load)
- Gemini CLI modal shows `gemini mcp add` command with env flags
- Support `?install=gemini` and `?install=gemini-cli` URL params
- Grid layout updated from 6 to 7 columns at large breakpoints
- Tests updated for new default-expanded behavior and 7 clients (19 pass)

## Test plan

- [ ] Visit `/mcp-install` — all 3 servers expanded, 7 client cards each
- [ ] Click Gemini CLI card — modal shows correct `gemini mcp add` command
- [ ] Visit `/mcp-install?server=mcp-gitlab&install=gemini` — auto-opens Gemini CLI modal
- [ ] Collapse/expand still works via accordion click
- [ ] All existing deeplinks (Cursor, VS Code) still work