### PR TITLE
ci: bump upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: './dist'
 


### PR DESCRIPTION
v3.0.1 internally references actions/upload-artifact@v4 unpinned, which violates the repo's sha_pinning_required policy and blocks Pages deploy. v4 pins it to a SHA.