### PR TITLE
fix(vite): manualChunks must be a function under vite 8/rolldown

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,11 +44,13 @@ export default defineConfig({
     assetsDir: 'assets',
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom'],
-          ui: ['@radix-ui/react-slot', '@radix-ui/react-toast', 'lucide-react'],
-          router: ['react-router-dom'],
-          form: ['react-hook-form'],
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('react-router')) return 'router'
+            if (id.includes('react-hook-form')) return 'form'
+            if (id.includes('@radix-ui') || id.includes('lucide-react')) return 'ui'
+            if (id.includes('react-dom') || /[\\/]react[\\/]/.test(id)) return 'vendor'
+          }
         },
         assetFileNames: 'assets/[name]-[hash][extname]',
         chunkFileNames: 'assets/[name]-[hash].js',


### PR DESCRIPTION
Vite 8 swaps to rolldown which requires `manualChunks` as a function rather than an object map. Converts the existing chunk strategy to the function form. Verified `pnpm build:github` succeeds locally.