### PR TITLE
fix: address react-hooks 7 violations and drop tsconfig baseUrl

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,19 +52,7 @@ export default [
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       'react/prop-types': 'off',
-      'react/react-in-jsx-scope': 'off',
-      'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/set-state-in-render': 'warn',
-      'react-hooks/refs': 'warn',
-      'react-hooks/purity': 'warn',
-      'react-hooks/immutability': 'warn',
-      'react-hooks/static-components': 'warn',
-      'react-hooks/use-memo': 'warn',
-      'react-hooks/preserve-manual-memoization': 'warn',
-      'react-hooks/error-boundaries': 'warn',
-      'react-hooks/globals': 'warn',
-      'react-hooks/gating': 'warn',
-      'react-hooks/config': 'warn'
+      'react/react-in-jsx-scope': 'off'
     }
   },
   {

--- a/src/pages/AdminUserManagement.tsx
+++ b/src/pages/AdminUserManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -30,29 +30,28 @@ export default function AdminUserManagement() {
   const [authLoading, setAuthLoading] = useState(true)
   const navigate = useNavigate()
 
-  const checkAuth = useCallback(async () => {
-    setAuthLoading(true)
-    try {
-      const currentUser = await githubWebAuth.getCurrentUser()
-      if (currentUser && !githubWebAuth.isUserAuthorized(currentUser.login)) {
-        // User is authenticated but not authorized
-        navigate('/unauthorized')
-        return
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const currentUser = await githubWebAuth.getCurrentUser()
+        if (cancelled) return
+        if (currentUser && !githubWebAuth.isUserAuthorized(currentUser.login)) {
+          navigate('/unauthorized')
+          return
+        }
+        setUser(currentUser)
+        setAllowedUsers(githubWebAuth.getAllowedUsers())
+      } catch {
+        if (!cancelled) setError('Authentication failed')
+      } finally {
+        if (!cancelled) setAuthLoading(false)
       }
-      setUser(currentUser)
-      // Load allowed users from service
-      setAllowedUsers(githubWebAuth.getAllowedUsers())
-    } catch {
-      setError('Authentication failed')
-    } finally {
-      setAuthLoading(false)
+    })()
+    return () => {
+      cancelled = true
     }
   }, [navigate])
-
-  // Check authentication on mount
-  useEffect(() => {
-    checkAuth()
-  }, [checkAuth])
 
   const handleAdminSignOut = () => {
     githubWebAuth.signOut()

--- a/src/pages/GratitudeAdmin.tsx
+++ b/src/pages/GratitudeAdmin.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -21,7 +21,6 @@ interface GratitudeMessage {
 
 export default function GratitudeAdmin() {
   const [allMessages, setAllMessages] = useState<GratitudeMessage[]>([])
-  const [filteredMessages, setFilteredMessages] = useState<GratitudeMessage[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [user, setUser] = useState<GitHubUser | null>(null)
@@ -31,77 +30,87 @@ export default function GratitudeAdmin() {
   const [excludeAdminRequests, setExcludeAdminRequests] = useState(true)
   const navigate = useNavigate()
 
-  const checkAuth = useCallback(async () => {
-    setAuthLoading(true)
-    try {
-      const currentUser = await githubWebAuth.getCurrentUser()
-      if (currentUser && !githubWebAuth.isUserAuthorized(currentUser.login)) {
-        // User is authenticated but not authorized
-        navigate('/unauthorized')
-        return
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const currentUser = await githubWebAuth.getCurrentUser()
+        if (cancelled) return
+        if (currentUser && !githubWebAuth.isUserAuthorized(currentUser.login)) {
+          navigate('/unauthorized')
+          return
+        }
+        setUser(currentUser)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Authentication failed')
+      } finally {
+        if (!cancelled) setAuthLoading(false)
       }
-      setUser(currentUser)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Authentication failed')
-    } finally {
-      setAuthLoading(false)
+    })()
+    return () => {
+      cancelled = true
     }
   }, [navigate])
-
-  // Check authentication on mount
-  useEffect(() => {
-    checkAuth()
-  }, [checkAuth])
 
   const handleAdminSignOut = () => {
     githubWebAuth.signOut()
     setUser(null)
   }
 
-  const loadMessages = useCallback(async () => {
-    if (!gratitudeService.isConfigured()) {
-      setError('GitHub API not configured. Please check environment variables.')
-      return
-    }
-
-    setLoading(true)
-    setError(null)
-
-    try {
-      const data = await gratitudeService.getAllIssues(50)
-      setAllMessages(data)
-      applyFilters(data, selectedLabels, excludeAdminRequests)
-    } catch (err) {
-      setError('Failed to load messages')
-      console.error('Error loading messages:', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [selectedLabels, excludeAdminRequests])
-
-  useEffect(() => {
-    if (user) {
-      loadMessages()
-    }
-  }, [user, loadMessages])
-
-  const applyFilters = (messages: GratitudeMessage[], labels: string[], excludeAdmin: boolean) => {
-    let filtered = [...messages]
-
-    // Filter out admin requests if enabled
-    if (excludeAdmin) {
+  const filteredMessages = useMemo(() => {
+    let filtered = allMessages
+    if (excludeAdminRequests) {
       filtered = filtered.filter(
         msg => !msg.labels.includes('admin-request') && !msg.labels.includes('admin-access-request')
       )
     }
-
-    // Filter by selected labels if any
-    if (labels.length > 0) {
-      filtered = filtered.filter(msg => labels.some(label => msg.labels.includes(label)))
+    if (selectedLabels.length > 0) {
+      filtered = filtered.filter(msg => selectedLabels.some(label => msg.labels.includes(label)))
     }
+    return filtered
+  }, [allMessages, selectedLabels, excludeAdminRequests])
 
-    setFilteredMessages(filtered)
-  }
+  const [loadCounter, setLoadCounter] = useState(0)
+
+  const configError = gratitudeService.isConfigured()
+    ? null
+    : 'GitHub API not configured. Please check environment variables.'
+  const displayError = error || configError
+
+  useEffect(() => {
+    if (!user || !gratitudeService.isConfigured()) return
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const data = await gratitudeService.getAllIssues(50)
+        if (cancelled) return
+        setAllMessages(data)
+      } catch (err) {
+        if (cancelled) return
+        setError('Failed to load messages')
+        console.error('Error loading messages:', err)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [user, loadCounter])
+
+  const reloadMessages = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    setLoadCounter(n => n + 1)
+  }, [])
+
+  const [weekStart] = useState(() => Date.now() - 7 * 24 * 60 * 60 * 1000)
+  const messagesThisWeek = useMemo(
+    () => filteredMessages.filter(m => new Date(m.createdAt).getTime() > weekStart).length,
+    [filteredMessages, weekStart]
+  )
 
   const getAllLabels = () => {
     const labelSet = new Set<string>()
@@ -112,17 +121,13 @@ export default function GratitudeAdmin() {
   }
 
   const toggleLabel = (label: string) => {
-    const newLabels = selectedLabels.includes(label)
-      ? selectedLabels.filter(l => l !== label)
-      : [...selectedLabels, label]
-    setSelectedLabels(newLabels)
-    applyFilters(allMessages, newLabels, excludeAdminRequests)
+    setSelectedLabels(prev =>
+      prev.includes(label) ? prev.filter(l => l !== label) : [...prev, label]
+    )
   }
 
   const toggleExcludeAdmin = () => {
-    const newExclude = !excludeAdminRequests
-    setExcludeAdminRequests(newExclude)
-    applyFilters(allMessages, selectedLabels, newExclude)
+    setExcludeAdminRequests(prev => !prev)
   }
 
   const formatDate = (dateString: string) => {
@@ -216,16 +221,16 @@ export default function GratitudeAdmin() {
                 {showMessages ? <EyeOff className='h-4 w-4' /> : <Eye className='h-4 w-4' />}
                 {showMessages ? 'Hide' : 'Show'} Messages
               </Button>
-              <Button onClick={loadMessages} disabled={loading}>
+              <Button onClick={reloadMessages} disabled={loading}>
                 <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
                 Refresh
               </Button>
             </div>
           </div>
 
-          {error && (
+          {displayError && (
             <div className='bg-red-50 border border-red-200 rounded-md p-4 mb-6'>
-              <p className='text-red-800'>{error}</p>
+              <p className='text-red-800'>{displayError}</p>
             </div>
           )}
 
@@ -247,14 +252,7 @@ export default function GratitudeAdmin() {
                     <div className='text-sm text-muted-foreground'>Filtered</div>
                   </div>
                   <div className='text-center'>
-                    <div className='text-2xl font-bold text-green-600'>
-                      {
-                        filteredMessages.filter(
-                          m =>
-                            new Date(m.createdAt) > new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-                        ).length
-                      }
-                    </div>
+                    <div className='text-2xl font-bold text-green-600'>{messagesThisWeek}</div>
                     <div className='text-sm text-muted-foreground'>This Week</div>
                   </div>
                   <div className='text-center'>

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -12,52 +12,43 @@ export default function OAuthCallback() {
   const [error, setError] = useState<string | null>(null)
   const [user, setUser] = useState<GitHubUser | null>(null)
 
-  const handleOAuthCallback = useCallback(async () => {
-    try {
-      const code = searchParams.get('code')
-      const state = searchParams.get('state')
-      const errorParam = searchParams.get('error')
+  useEffect(() => {
+    let cancelled = false
+    let redirectTimer: ReturnType<typeof setTimeout> | undefined
+    void (async () => {
+      try {
+        const code = searchParams.get('code')
+        const state = searchParams.get('state')
+        const errorParam = searchParams.get('error')
 
-      // Check for OAuth errors
-      if (errorParam) {
-        throw new Error(`OAuth error: ${errorParam}`)
-      }
+        if (errorParam) throw new Error(`OAuth error: ${errorParam}`)
+        if (!code || !state) throw new Error('Missing OAuth parameters')
 
-      if (!code || !state) {
-        throw new Error('Missing OAuth parameters')
-      }
+        const authenticatedUser = await githubWebAuth.handleCallback(code, state)
+        if (cancelled) return
 
-      // Handle the OAuth callback
-      const authenticatedUser = await githubWebAuth.handleCallback(code, state)
+        if (!authenticatedUser) throw new Error('Authentication failed')
 
-      if (authenticatedUser) {
-        // Check if user is authorized
         if (!githubWebAuth.isUserAuthorized(authenticatedUser.login)) {
-          // User authenticated successfully but not authorized
           navigate('/unauthorized')
           return
         }
 
         setUser(authenticatedUser)
         setStatus('success')
-
-        // Redirect to admin dashboard after a brief delay
-        setTimeout(() => {
-          navigate('/admin/gratitude')
-        }, 2000)
-      } else {
-        throw new Error('Authentication failed')
+        redirectTimer = setTimeout(() => navigate('/admin/gratitude'), 2000)
+      } catch (err) {
+        if (cancelled) return
+        console.error('OAuth callback error:', err)
+        setError(err instanceof Error ? err.message : 'Authentication failed')
+        setStatus('error')
       }
-    } catch (err) {
-      console.error('OAuth callback error:', err)
-      setError(err instanceof Error ? err.message : 'Authentication failed')
-      setStatus('error')
+    })()
+    return () => {
+      cancelled = true
+      if (redirectTimer) clearTimeout(redirectTimer)
     }
   }, [searchParams, navigate])
-
-  useEffect(() => {
-    handleOAuthCallback()
-  }, [handleOAuthCallback])
 
   const handleRetry = () => {
     navigate('/admin/gratitude')

--- a/src/pages/Repositories.tsx
+++ b/src/pages/Repositories.tsx
@@ -140,14 +140,22 @@ export default function Repositories() {
     })
   }, [repos, filter, sortBy, sortDirection])
 
-  // Reset visible count when filter/sort changes
-  useEffect(() => {
+  const handleFilterChange = useCallback((next: FilterOption) => {
+    setFilter(next)
     setVisibleCount(PAGE_SIZE)
-  }, [filter, sortBy, sortDirection])
+  }, [])
+
+  const handleSortChange = useCallback((nextSortBy: SortOption, nextDirection: SortDirection) => {
+    setSortBy(nextSortBy)
+    setSortDirection(nextDirection)
+    setVisibleCount(PAGE_SIZE)
+  }, [])
 
   // Infinite scroll via IntersectionObserver
   const totalCountRef = useRef(filteredAndSortedRepos.length)
-  totalCountRef.current = filteredAndSortedRepos.length
+  useEffect(() => {
+    totalCountRef.current = filteredAndSortedRepos.length
+  }, [filteredAndSortedRepos])
 
   const loadMore = useCallback(() => {
     setVisibleCount(prev => Math.min(prev + PAGE_SIZE, totalCountRef.current))
@@ -175,10 +183,10 @@ export default function Repositories() {
   const totalStars = repos.reduce((sum, repo) => sum + repo.stargazers_count, 0)
 
   const handleSort = (option: SortOption) => {
-    if (sortBy === option) setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
-    else {
-      setSortBy(option)
-      setSortDirection('desc')
+    if (sortBy === option) {
+      handleSortChange(option, sortDirection === 'asc' ? 'desc' : 'asc')
+    } else {
+      handleSortChange(option, 'desc')
     }
   }
 
@@ -278,7 +286,7 @@ export default function Repositories() {
             ).map(([key, label, count]) => (
               <button
                 key={key}
-                onClick={() => setFilter(key)}
+                onClick={() => handleFilterChange(key)}
                 aria-pressed={filter === key}
                 className={`
                   px-3 py-1.5 text-xs font-medium rounded-md transition-all cursor-pointer

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "ignoreDeprecations": "6.0",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
@@ -26,15 +25,8 @@
     "noUncheckedIndexedAccess": true,
 
     /* Paths */
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@/components/*": ["src/components/*"],
-      "@/pages/*": ["src/pages/*"],
-      "@/hooks/*": ["src/hooks/*"],
-      "@/utils/*": ["src/utils/*"],
-      "@/store/*": ["src/store/*"],
-      "@/types/*": ["src/types/*"]
+      "@/*": ["./src/*"]
     },
 
     /* Additional */


### PR DESCRIPTION
Closes #110, closes #111.

## React-hooks 7 refactors
Real refactors — no eslint-disable comments — restoring the global `react-hooks/*` rules to error severity:

- **Auth/OAuth bootstrap effects** (`AdminUserManagement`, `GratitudeAdmin`, `OAuthCallback`): rewritten to run side effects after async resolution with a cancelled flag, so setState never fires synchronously inside the effect body.
- **GratitudeAdmin** filtering: `filteredMessages` is now derived via `useMemo` from `allMessages` + filter state. Removed cascading `setFilteredMessages` from handlers and the TDZ on `applyFilters`.
- **GratitudeAdmin** config error: `gratitudeService.isConfigured()` error derived during render instead of synced via setError in an effect.
- **GratitudeAdmin** weekly threshold: `Date.now()` moved into a `useState` initializer so the purity rule no longer trips inside `useMemo`.
- **Repositories**: visible-count reset moved out of a filter-change effect into the filter/sort handlers; ref write moved out of render into a `useEffect`.
- Drop the global `react-hooks/*: 'warn'` overrides added during the bump.

## tsconfig
- Drop `baseUrl` and the related `ignoreDeprecations` shim.
- Collapse `paths` to a single `@/* -> ./src/*` mapping (TS 5+ resolves `paths` relative to the tsconfig dir without `baseUrl`).

## Verified
- `pnpm lint:check`: 0 errors
- `pnpm typecheck`: clean
- `pnpm test`: 70 passed
- `pnpm build:github`: build OK