### PR TITLE
fix: MCP page icons via CSP allowlist + SPA catch-all route

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; worker-src 'self'; manifest-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://avatars.githubusercontent.com https://github.com; connect-src 'self' https://api.github.com https://github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; script-src 'self'; worker-src 'self'; manifest-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https://avatars.githubusercontent.com https://github.com https://cdn.simpleicons.org https://upload.wikimedia.org; connect-src 'self' https://api.github.com https://github.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
 import type { ComponentType } from 'react'
-import { BrowserRouter as Router, Routes, Route, Link, useLocation } from 'react-router-dom'
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Link,
+  Navigate,
+  useLocation,
+} from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { User, Blocks } from 'lucide-react'
 import GitHubIcon from '@/components/icons/GitHubIcon'
@@ -98,6 +105,7 @@ function AppContent() {
           <Route path='/' element={<About />} />
           <Route path='/repositories' element={<Repositories />} />
           <Route path='/mcp-install' element={<McpInstall />} />
+          <Route path='*' element={<Navigate to='/' replace />} />
         </Routes>
       </main>
 


### PR DESCRIPTION
Two small follow-ups after the Pages cutover.

**MCP icons**: the strict CSP added in #121 didn't list `cdn.simpleicons.org` or `upload.wikimedia.org`, so all the editor/client logos on `/mcp-install` (Cursor, Claude, Windsurf, IntelliJ, Gemini, ModelContextProtocol, VS Code) silently failed to load. Both CDNs are now allowed in `img-src`.

**Catch-all route**: `<Route path='*' element={<Navigate to='/' replace />} />` so removed routes (`/gratitude`, `/admin/*`, etc.) land on About after the 404.html SPA round-trip instead of rendering a blank shell.